### PR TITLE
use storyStoreV7

### DIFF
--- a/storybook/default-config.js
+++ b/storybook/default-config.js
@@ -1,12 +1,12 @@
 module.exports = {
-  // need to mention this for webpack 5, storybook default is webpack 4
-  // do we need to support webpack 4? (dotcom & memex use webpack 5)
   core: {
     builder: {
+      // do we need to support webpack 4? (dotcom & memex use webpack 5)
       name: 'webpack5',
       options: { lazyCompilation: true, fsCache: true }
     }
   },
+  features: { storyStoreV7: true }, // required for lazyCompilation
 
   // look through entire repo for *.stories.ts files
   // might be slow, need to test


### PR DESCRIPTION
storyStoreV7 is required for lazyCompilation. [Blog reference](https://storybook.js.org/blog/storybook-lazy-compilation-for-webpack/)