### PR TITLE
performance optimisation: scope down stories to common directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@storybook/manager-webpack5": "^6.5.0-alpha.64",
         "@storybook/react": "^6.5.0-alpha.64",
         "@storybook/testing-library": "^0.0.11",
+        "common-path": "^1.0.1",
         "execa": "^5.1.1",
         "pkg-dir": "^5.0.0",
         "storybook-addon-performance": "^0.16.1"
@@ -11165,6 +11166,14 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/common-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-path/-/common-path-1.0.1.tgz",
+      "integrity": "sha512-C8zvr4tVGRIJpbrh7WxeFZPvUkc2PHWx2IvxAUtuJCAiOLx0n6N4Xaab0C7wM+HDfXLqUQg7H9FoIjyxn/4IiA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/common-path-prefix": {
@@ -31984,6 +31993,11 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+    },
+    "common-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-path/-/common-path-1.0.1.tgz",
+      "integrity": "sha512-C8zvr4tVGRIJpbrh7WxeFZPvUkc2PHWx2IvxAUtuJCAiOLx0n6N4Xaab0C7wM+HDfXLqUQg7H9FoIjyxn/4IiA=="
     },
     "common-path-prefix": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@storybook/manager-webpack5": "^6.5.0-alpha.64",
     "@storybook/react": "^6.5.0-alpha.64",
     "@storybook/testing-library": "^0.0.11",
+    "common-path": "^1.0.1",
     "execa": "^5.1.1",
     "pkg-dir": "^5.0.0",
     "storybook-addon-performance": "^0.16.1"


### PR DESCRIPTION
storybook watches the `stories` field in config to look for changes, it accepts a glob pattern like `./**/*.stories.@tsx|jsx`

The best default and easiest value for this field would be `./src/**/*.stories.tsx`, however this is also super slow  to compile. It's faster if you scope it down, example: `./app/assets/modules/react-shared/**/*.stories.tsx`

This optimisation looks for all `*.stories` files and finds the common parent for them.

- for primer/react, that's just `./src/**/*.stories.tsx` so not that impressive
- for memex that's `src/client/components/common/**/*.stories.tsx` which is a huge improvement
- for gh/gh that's `app/assets/modules/react-shared/**/*.stories.tsx` which is crucial given the size of the repo!
