### PR TITLE
Create release action with approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-on-approval:
+    name: Release on approval
+    environment: 'needs-approval'
+    uses: primer/.github/.github/workflows/release.yml@main
+    secrets:
+      gh_token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
+      npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
It's too early to adopt the proper workflow with changesets, so instead there are 2 types of release in this repo:

1. release canary: Each pull request and push get's a canary version published for testing
2. release stable on approval: On `main`, there is an action that can be "approved" to publish a new version